### PR TITLE
Add thesis/design checkboxes to bachelor titlepage（内封, A.K.A 扉页, in Chinese）

### DIFF
--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -7632,7 +7632,7 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\hit@second@titlepage@harbinbachelor}
-% \changes{v3.1e}{0000/00/00}{本科生内封上方文字添加毕业论文或设计的选择框，由于目前hitheis不支持毕业论文，因此对勾写死在毕业论文上}
+% \changes{v3.1e}{0000/00/00}{本科生内封上方文字添加毕业论文或设计的选择框，由于目前hitheis不支持毕业设计，因此对勾写死在毕业论文上}
 %    \begin{macrocode}
 \newcommand{\hit@second@titlepage@harbinbachelor}{
   \begin{center}

--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -7632,12 +7632,24 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\hit@second@titlepage@harbinbachelor}
+% \changes{v3.1e}{0000/00/00}{本科生内封上方文字添加毕业论文或设计的选择框，由于目前hitheis不支持毕业论文，因此对勾写死在毕业论文上}
 %    \begin{macrocode}
 \newcommand{\hit@second@titlepage@harbinbachelor}{
   \begin{center}
     \vspace*{-3mm}
     \begin{flushright}
-      \xiaosi\hit@secretlevel：公开\hspace{14mm}
+      \xiaosi
+      % SimSun下效果最好
+      \raisebox{0em}{% 盒子高度调整，感觉Fandol用-.05em比较好
+        \fboxsep=0pt\fbox{\rule{.7em}{0pt}\rule{0pt}{.7em}}%
+        \llap{\raisebox{0em}{\checkmark}}%
+      }\hspace{.05em}毕业论文%
+      \hspace{1em}%
+      \raisebox{0em}{% 盒子高度调整，同上
+        \fboxsep=0pt\fbox{\rule{.7em}{0pt}\rule{0pt}{.7em}}%
+      }\hspace{.05em}毕业设计%
+      \hfill%
+      \hit@secretlevel：公开%\hspace{14mm}% 右侧不再留空白
     \end{flushright}
     \vspace{2.1cm}
     {\songti\bfseries\xiaoer \hit@bachelor@cxuewei    \hit@bachelor@cthesisname}\\[0.8cm]


### PR DESCRIPTION
Add thesis/design checkboxes to bachelor titlepage（内封, A.K.A 扉页, in Chinese）

P.S.: Checkbox hardcoded to thesis (design selection not yet supported) since HIThesis does not currently support the bachelor design template

<img width="906" height="483" alt="截屏2026-01-08 22 14 03" src="https://github.com/user-attachments/assets/fd45be3d-744a-4c38-8daf-cb09135faa98" />
