### PR TITLE
统一模块命名:docstrip 守卫改为 cls-职责 顺序，新增 CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,324 @@
+# 贡献指南
+
+感谢有意参与 HIThesis 的维护与改进。本文记录了贡献者在动手前需要了解的项目结构、开发约定与提交流程。文档面向 **代码贡献者**（修 bug、加功能、改文档结构）。仅作为模板用户提交 issue 或反馈样式问题不需要阅读本文。
+
+---
+
+## 1. 项目结构速览
+
+```
+hithesis/
+├── hithesis.dtx          <- 主源文件（模块化代码、用户手册、bst/ist）
+├── hithesis-eps.dtx      <- EPS 图像数据（校徽、封面、示例插图）
+├── hithesis.ins          <- docstrip 驱动文件
+├── Makefile              <- 构建入口
+├── latexmkrc             <- latexmk 配置
+├── dtx-toc.py            <- dtx 结构扫描工具
+├── README.md
+├── CONTRIBUTING.md       <- 本文
+├── examples/
+│   ├── hitbook/{chinese,english}/   <- 毕业论文示例
+│   └── hitart/{reports,reportplus}/ <- 开题/中期/博士中期示例
+└── .github/              <- Issue / PR 模板、CI 配置
+```
+
+构建产物（`*.cls`、`*.cfg`、`*.bst`、`*.ist`、`modules/*.sty`、`*.eps`、`*.pdf`）均由源文件生成，**禁止进版本库**。
+
+## 2. 开发环境
+
+| 工具 | 用途 | 必需性 |
+|---|---|---|
+| TeX Live ≥ 2024 | 编译模板与示例 | 必需 |
+| Python 3.6+ | 跑 `dtx-toc.py` | 必需 |
+| Make | 走 Makefile | 推荐 |
+
+### 常用命令
+
+```shell
+make cls          # 从 dtx + ins 生成所有 cls/cfg/sty/bst/ist/eps
+make doc          # 编译用户手册 hithesis.pdf
+make toc          # 打印 dtx 模块结构到 stdout
+make toc-update   # 把模块结构写回 dtx 顶部的 TOC 块（幂等）
+make clean        # 清理所有生成产物
+make distclean    # clean + 删发行 zip
+```
+
+在示例目录里：
+
+```shell
+cd examples/hitbook/chinese
+make thesis       # 编译示例论文 thesis.pdf
+
+cd examples/hitart/reports
+make report       # 编译示例报告 report.pdf
+```
+
+## 3. dtx 与模块导航
+
+主源 `hithesis.dtx` 按 docstrip 守卫块（Guard Block）划分。**先跑 `make toc` 看全貌**：
+
+```shell
+$ make toc
+==== Major sections ====
+  3196   artpluscls
+  3843   artcls
+  4886   bookcls
+  9472   dtx-style
+
+==== Modules (first .. last; block count) ====
+   108   driver                   108-120 (1 block)
+  3196   artpluscls               3196-3835 (3 blocks)
+  3220   artplus-options          3220-3363 (1 block)
+  3392   artplus-deps             3392-3767 (7 blocks)
+  ...
+```
+
+输出每行的行号可直接跳转：编辑器里 `:数字` 即可。模块守卫块碎片化（如 art-deps 9 块）是模块化时为保持加载顺序的设计。
+
+每个模块在 dtx 内部有 banner 注释：
+
+```
+% ^^A ======================================================================
+% ^^A Module book-options: 文档类选项的声明与后处理（type/campus/fontset 等）（book）
+% ^^A ======================================================================
+%<*book-options>
+```
+
+dtx 顶部还有一段由 `make toc-update` 自动维护的静态 TOC，用 `% ^^A` 包裹，对 LaTeX 与 docstrip 均不可见。
+
+### 3.1 命名约定
+
+各处统一为 **cls 在前、职责在后**：
+
+| 类型 | 例子 | 模式 |
+|---|---|---|
+| 模块 docstrip 守卫 | `%<*book-options>` | `<cls>-<职责>` |
+| 模块文件名 | `hithesisbook-options.sty` | `hithesis<cls>-<职责>` |
+| `\ProvidesPackage` 标识 | `hithesisbook-options` | 同文件名 |
+| cls 守卫 | `%<*bookcls>` | `<cls>cls` |
+| cfg 守卫 | `%<*bookcfg>` | `<cls>cfg` |
+
+模块文件名前缀 `hithesis` 是 LaTeX 包惯例；其余字段顺序一律 cls 优先。共享资源（bst、ist、dtx-style 等）无 cls 后缀。
+
+## 4. 模块化的硬性约定
+
+下列原则贯穿整个 v3.2Z 架构。**不遵守的 PR 不会被合并。**
+
+### 4.1 用户接口绝对不得改变
+
+模板已有数千篇论文在用，任何 PR 不得改变：
+
+- `\documentclass` 接受的选项名与默认值
+- `\hitsetup{}` 接受的 key 名
+- 已对外暴露的命令名（`\inlinecite`、`\bicaption`、`\rcell` 等）
+- 已对外暴露的环境名（`cabstract`、`publist`、`appendix` 等）
+
+新增是允许的，**重命名/删除/默认值改动是禁止的**，除非走完废弃期（见 §9）。
+
+### 4.2 book / art / artplus 三模板类完全独立
+
+三个 cls（毕业论文 / 开题中期 / 深圳博士中期）的代码物理隔离，由独立的 `*-book` / `*-art` / `*-artplus` 模块承载。即使内容相似也不跨 cls 共享。
+
+理由：三模板类理应对应三套学校规范，规范常各自演化，强行耦合会让某时期的碰巧相似在规范独立改变时维护难度增大。
+
+例外：`hithesis.bst`（或将废弃并切换到 biblatex-gb7714）、`hithesis-eps.dtx` 是跨类共享的。
+
+### 4.3 一个模块一个职责
+
+模块名应反映其唯一职责：
+
+- ✅ `chapter-book` 只管 book 类的章节标题格式
+- ✅ `bib-book` 只管 book 类的参考文献加载与样式
+- ❌ `floats-book` 兼管列表+定理+段落+引用
+
+新加代码前问：**这段代码语义上属于哪个模块？**找到答案再写。若找不到，先考虑拆出新模块（参考 §5）。
+
+### 4.4 `\ProvidesPackage` 必须是模块第一条非注释语句
+
+每个 `%<*modname>` 块开头：
+
+```
+%<*modname>
+\ProvidesPackage{hithesisX-modname}[0000/00/00 v3.2a hithesis-X modname]
+... 实际代码 ...
+%</modname>
+```
+
+错位会让 `.log` 横幅 "先做事后报名"，且影响错误归属。
+
+### 4.5 `\changes` 历史条目
+
+新增任何模块、迁移、显著语义变化，都要写 `\changes` 条目：
+
+```latex
+% \changes{v3.2a}{0000/00/00}{某模块从某处拆出至某处，理由}
+```
+
+- 版本号 `v3.2a` 是当前开发版（合入 master 后由维护者改为正式版本）
+- 日期 `0000/00/00` 是占位符，正式发版时统一替换
+- 描述要写**为什么**做这件事，不只是写做了什么
+
+## 5. 新增模块的标准步骤
+
+假设要新增 `bookcls` 的 `book-footnote` 模块（已存在，仅作示范）：
+
+1. **在 dtx 中加守卫块** —— 选合适位置（按现有 cls 内部顺序），加：
+
+   ```
+   % ^^A ======================================================================
+   % ^^A Module book-footnote: 脚注样式与编号（book）
+   % ^^A ======================================================================
+   %<*book-footnote>
+   \ProvidesPackage{hithesisbook-footnote}[0000/00/00 v3.2a hithesis-book footnote]
+   ...实际代码...
+   %</book-footnote>
+   ```
+
+2. **在 cls 加载点插入 `\RequirePackage{...}`** —— 在 dtx 对应 cls 块里（找到 `%<*bookcls>` 区域）：
+
+   ```latex
+   \RequirePackage{hithesisbook-footnote}
+   ```
+
+   **加载顺序敏感**：如果新模块依赖 enumitem/hyperref 等已在 `X-deps` 加载的包，要放在 X-deps **之后**。
+
+3. **在 `hithesis.ins` 加生成项**：
+
+   ```
+   \hitbookmod{footnote}     % 或 \hitartmod{} / \hitartplusmod{}
+   ```
+
+4. **跑 `make cls` + `make toc-update`** —— 验证生成正常，自动刷新 dtx 顶部 TOC。
+
+5. **本地编译验证** —— 至少跑过受影响 cls 的示例（`make thesis` / `make report`），确认无 LaTeX 报错、PDF 渲染正常。
+
+6. **如果是用户可见的功能改动**，更新手册 `\subsection{模块说明}` 表格（dtx 内）。
+
+## 6. 修改现有模块
+
+不涉及新模块的改动（修 bug、调样式、迁移代码）：
+
+1. 用 `make toc` 定位目标模块
+2. 改代码，加 `\changes{v3.2a}{0000/00/00}{...}` 条目
+3. 跑 `make cls` 重新生成
+4. 编译受影响 cls 的示例验证
+5. `make toc-update`（如果改动影响行号，自动刷新静态 TOC）
+
+## 7. 提交规范
+
+### 7.1 commit 消息
+
+格式：
+
+```
+<前缀>: <一句话摘要>
+
+详细说明：改了什么、为什么、影响范围、verification 结果。
+```
+
+前缀建议：
+
+- 模块名前缀：`floats-book:` / `glossary-art:`
+- 类别前缀：`docs:` / `build:` / `fix:` / `feat:`
+
+### 7.2 严禁出现的内容
+
+- **`Co-Authored-By: Claude ...` 一类 AI 工具署名** —— 项目偏好显式人类作者，AI 辅助不写进 trailer
+- 包含临时调试代码（被注释的 `\typeout{...}` 等）
+- 直接拷贝其他模板代码而未注明出处与许可
+
+### 7.3 commit 粒度
+
+- 一个 commit 一件事，方便 reviewer 逐 commit 审
+- 大重构按阶段分多个 commit
+- 跨模块 / 跨 cls 的批量改动允许放在一个 commit，但要在 commit 消息中明确列出涉及的模块
+
+## 8. 分支与 PR 流程
+
+### 8.1 分支
+
+- 维护者主仓库（upstream/hithesis/hithesis）的 `master` 是稳定分支
+- `dev` 是开发分支，维护者从此处合入新版本
+- 协作者从 `dev` 派生 feature 分支：`feature/<topic>` 或简短描述
+
+### 8.2 PR 流程（fork 工作流）
+
+```shell
+# 1. fork 后克隆你的 fork
+git clone https://github.com/<you>/hithesis.git
+cd hithesis
+git remote add upstream https://github.com/hithesis/hithesis.git
+
+# 2. 从最新 dev 派生分支
+git fetch upstream
+git checkout -b feature/my-topic upstream/dev
+
+# 3. 改 → commit → push 到自己 fork
+git push -u origin feature/my-topic
+
+# 4. 在 GitHub 上开 PR，base=upstream/dev，head=origin/feature/my-topic
+```
+
+**禁止**：
+
+- 直推 `upstream/master`
+- `git push --force` 到 `upstream` 任意分支
+- 把 `feature/X` 推成 `master`
+
+如果有 write 权限，也走 PR 流程，不要绕过 review。
+
+### 8.3 PR 需要包含
+
+- 一句话说明：解决了什么问题
+- 关键改动列表（按模块或 commit）
+- 用户接口影响声明：是 zero-impact 还是有 user-visible 变化
+- 本地验证结果：跑过哪些示例、是否 PDF 渲染正常
+- 截图或 PDF 链接（如果改动影响渲染）
+
+## 9. 演进策略
+
+### 9.1 加新选项 / 命令
+
+允许，但要符合：
+
+- 默认值保持旧行为
+- 文档（手册或 thesis.tex 注释）说明用途
+- 加 `\changes` 条目
+
+### 9.2 移除老接口
+
+需要走废弃期：
+
+1. **opt-in 期**（≥ 6 个月）—— 新接口可用，旧接口保留，文档提示推荐新接口
+2. **默认切换**（v4.0 这类大版本）—— 默认改为新接口，旧接口保留为兼容选项
+3. **观察期**（≥ 24 个月）—— 等用户论文完成完整培养周期
+4. **彻底移除**（v5.0 大版本）—— 删旧代码
+
+参考：本仓库 issue 区"subfigure → subcaption 迁移计划"。
+
+### 9.3 跨 cls 改动
+
+如果一个改动对 book/art/artplus 都适用，**必须三处同步**。否则会让模块矩阵不对称。例外：仅一个 cls 适用的规范变化。
+
+## 10. 常见陷阱
+
+| 陷阱 | 现象 | 解决 |
+|---|---|---|
+| hyperref 加载顺序 | 引用/书签锚点错乱 | `hyperref` 已在 `X-deps` 内部精确位置加载，不要在其他模块重新加载 |
+| enumitem 覆盖 cft* 长度 | 目录间距异常 | X-toc 模块必须在 X-deps 之后加载（深圳硕士目录的历史教训） |
+| subfigure 不可改 | 用户论文用 `\subfigure[]{}` 语法 | 不要切换到 subcaption，会破坏所有现存论文 |
+| `\ProvidesPackage` 错位 | 模块 .log 输出乱 | 必须放在 `%<*modname>` 紧后第一行非注释语句 |
+| docstrip 守卫缺失 | 模块代码漏进其他文件 | 每个 `%<*X>` 必须有匹配的 `%</X>` |
+| `\changes` 漏写 | 看不到历史脉络 | 任何语义变化都加，包括迁移、重命名、删除 |
+
+## 11. 找谁帮助
+
+- **GitHub Issues** —— https://github.com/hithesis/hithesis/issues
+- **QQ 群** —— 见 README.md
+- **维护者邮件** —— 见 dtx 顶部许可声明
+
+提问前请先 `make toc` 看模块结构、`grep` 一下 dtx 看是否已有类似实现。
+
+---
+
+**最后一句话**：HIThesis 已经被千余学生用着，每一次 PR 都可能影响他们的论文。**保守、可回滚、可验证** 是这个项目的核心原则。

--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -33,50 +33,50 @@
 % ^^A     1169   bst                      1169-2636 (3 blocks)
 % ^^A     3152   ist                      3152-3158 (1 block)
 % ^^A     3172   artpluscls               3172-3821 (3 blocks)
-% ^^A     3181   options-artplus          3181-3324 (1 block)
-% ^^A     3346   deps-artplus             3346-3745 (7 blocks)
-% ^^A     3376   fonts-artplus            3376-3437 (1 block)
-% ^^A     3478   hyperlink-artplus        3478-3494 (1 block)
-% ^^A     3506   geometry-artplus         3506-3522 (1 block)
-% ^^A     3560   chapter-artplus          3560-3613 (1 block)
-% ^^A     3623   meta-artplus             3623-3664 (1 block)
-% ^^A     3670   pagestyle-artplus        3670-3679 (1 block)
-% ^^A     3685   frontmatter-artplus      3685-3737 (1 block)
-% ^^A     3749   bib-artplus              3749-3813 (1 block)
+% ^^A     3181   artplus-options          3181-3324 (1 block)
+% ^^A     3346   artplus-deps             3346-3745 (7 blocks)
+% ^^A     3376   artplus-fonts            3376-3437 (1 block)
+% ^^A     3478   artplus-hyperlink        3478-3494 (1 block)
+% ^^A     3506   artplus-geometry         3506-3522 (1 block)
+% ^^A     3560   artplus-chapter          3560-3613 (1 block)
+% ^^A     3623   artplus-meta             3623-3664 (1 block)
+% ^^A     3670   artplus-pagestyle        3670-3679 (1 block)
+% ^^A     3685   artplus-frontmatter      3685-3737 (1 block)
+% ^^A     3749   artplus-bib              3749-3813 (1 block)
 % ^^A     3833   artcls                   3833-4873 (3 blocks)
-% ^^A     3842   options-art              3842-3986 (1 block)
-% ^^A     4011   deps-art                 4011-4784 (9 blocks)
-% ^^A     4041   fonts-art                4041-4102 (1 block)
-% ^^A     4175   hyperlink-art            4175-4191 (1 block)
-% ^^A     4203   geometry-art             4203-4230 (1 block)
-% ^^A     4264   floats-art               4264-4288 (1 block)
-% ^^A     4316   chapter-art              4316-4391 (1 block)
-% ^^A     4395   pagestyle-art            4395-4444 (1 block)
-% ^^A     4474   meta-art                 4474-4511 (1 block)
-% ^^A     4515   frontmatter-art          4515-4777 (2 blocks)
-% ^^A     4688   toc-art                  4688-4743 (1 block)
-% ^^A     4788   bib-art                  4788-4865 (1 block)
+% ^^A     3842   art-options              3842-3986 (1 block)
+% ^^A     4011   art-deps                 4011-4784 (9 blocks)
+% ^^A     4041   art-fonts                4041-4102 (1 block)
+% ^^A     4175   art-hyperlink            4175-4191 (1 block)
+% ^^A     4203   art-geometry             4203-4230 (1 block)
+% ^^A     4264   art-floats               4264-4288 (1 block)
+% ^^A     4316   art-chapter              4316-4391 (1 block)
+% ^^A     4395   art-pagestyle            4395-4444 (1 block)
+% ^^A     4474   art-meta                 4474-4511 (1 block)
+% ^^A     4515   art-frontmatter          4515-4777 (2 blocks)
+% ^^A     4688   art-toc                  4688-4743 (1 block)
+% ^^A     4788   art-bib                  4788-4865 (1 block)
 % ^^A     4885   bookcls                  4885-5316 (2 blocks)
-% ^^A     4894   options-book             4894-5282 (1 block)
-% ^^A     5320   deps-book                5320-5661 (4 blocks)
-% ^^A     5358   fonts-book               5358-5909 (2 blocks)
-% ^^A     5498   hyperlink-book           5498-5536 (1 block)
-% ^^A     5551   geometry-book            5551-5609 (1 block)
-% ^^A     5673   glossary-book            5673-5716 (1 block)
-% ^^A     5720   mainmatter-book          5720-5802 (1 block)
-% ^^A     5949   pagestyle-book           5949-6125 (1 block)
-% ^^A     6141   paragraph-book           6141-6168 (1 block)
-% ^^A     6179   footnote-book            6179-6210 (1 block)
-% ^^A     6221   math-book                6221-6292 (1 block)
+% ^^A     4894   book-options             4894-5282 (1 block)
+% ^^A     5320   book-deps                5320-5661 (4 blocks)
+% ^^A     5358   book-fonts               5358-5909 (2 blocks)
+% ^^A     5498   book-hyperlink           5498-5536 (1 block)
+% ^^A     5551   book-geometry            5551-5609 (1 block)
+% ^^A     5673   book-glossary            5673-5716 (1 block)
+% ^^A     5720   book-mainmatter          5720-5802 (1 block)
+% ^^A     5949   book-pagestyle           5949-6125 (1 block)
+% ^^A     6141   book-paragraph           6141-6168 (1 block)
+% ^^A     6179   book-footnote            6179-6210 (1 block)
+% ^^A     6221   book-math                6221-6292 (1 block)
 % ^^A     6300   bookcfg                  6300-8088 (5 blocks)
 % ^^A     6356   artcfg                   6356-6560 (1 block)
-% ^^A     6574   floats-book              6574-6984 (1 block)
-% ^^A     7094   chapter-book             7094-7560 (1 block)
-% ^^A     7564   meta-book                7564-7658 (1 block)
-% ^^A     8096   frontmatter-book         8096-8859 (1 block)
-% ^^A     8863   toc-book                 8863-9019 (1 block)
-% ^^A     9023   appendix-book            9023-9285 (1 block)
-% ^^A     9293   bib-book                 9293-9448 (1 block)
+% ^^A     6574   book-floats              6574-6984 (1 block)
+% ^^A     7094   book-chapter             7094-7560 (1 block)
+% ^^A     7564   book-meta                7564-7658 (1 block)
+% ^^A     8096   book-frontmatter         8096-8859 (1 block)
+% ^^A     8863   book-toc                 8863-9019 (1 block)
+% ^^A     9023   book-appendix            9023-9285 (1 block)
+% ^^A     9293   book-bib                 9293-9448 (1 block)
 % ^^A     9466   dtx-style                9466-9696 (2 blocks)
 % ^^A
 % ^^A Total: 9713 lines.
@@ -3176,9 +3176,9 @@ delim_1 "\\hspace*{\\fill}"
 \RequirePackage{hithesisartplus-options}
 %</artpluscls>
 % ^^A ======================================================================
-% ^^A Module options-artplus: 文档类选项的声明与后处理（type/campus/fontset 等）（artplus）
+% ^^A Module artplus-options: 文档类选项的声明与后处理（type/campus/fontset 等）（artplus）
 % ^^A ======================================================================
-%<*options-artplus>
+%<*artplus-options>
 \ProvidesPackage{hithesisartplus-options}[0000/00/00 v3.2a hithesis-artplus options]
 %    \end{macrocode}
 %
@@ -3304,7 +3304,7 @@ delim_1 "\\hspace*{\\fill}"
 \fi
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{选项后处理（AutoFakeBold 与 fontset 透传）从 artpluscls 移入 options-artplus 模块}
+% \changes{v3.2a}{0000/00/00}{选项后处理（AutoFakeBold 与 fontset 透传）从 artpluscls 移入 artplus-options 模块}
 %    \begin{macrocode}
 \RequirePackage{ifthen}
 \ifthenelse
@@ -3321,7 +3321,7 @@ delim_1 "\\hspace*{\\fill}"
   }%
   \PassOptionsToClass{fontset=\hit@fontset}{ctexart}
 }%
-%</options-artplus>
+%</artplus-options>
 %<*artpluscls>
 \LoadClass[a4paper,UTF8,zihao=-4,scheme=plain]{ctexart}
 %    \end{macrocode}
@@ -3337,13 +3337,13 @@ delim_1 "\\hspace*{\\fill}"
 \RequirePackage{hithesisartplus-deps}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{LoadClass 之后的所有标准包加载、配置整体打包至 deps-artplus 模块；artpluscls 仅保留 LoadClass 与早期模块加载}
+% \changes{v3.2a}{0000/00/00}{LoadClass 之后的所有标准包加载、配置整体打包至 artplus-deps 模块；artpluscls 仅保留 LoadClass 与早期模块加载}
 %    \begin{macrocode}
 %</artpluscls>
 % ^^A ======================================================================
-% ^^A Module deps-artplus: 第三方宏包集中加载与基础配置（含 hyperlink/geometry 内联）（artplus）
+% ^^A Module artplus-deps: 第三方宏包集中加载与基础配置（含 hyperlink/geometry 内联）（artplus）
 % ^^A ======================================================================
-%<*deps-artplus>
+%<*artplus-deps>
 \ProvidesPackage{hithesisartplus-deps}[0000/00/00 v3.2a hithesis-artplus deps]
 %    \end{macrocode}
 %
@@ -3367,13 +3367,13 @@ delim_1 "\\hspace*{\\fill}"
 % 删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG TermesX 与 TG Heros.
 % \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG Termes 与 TG Heros.}
 % \changes{v3.0.19}{2022/05/05}{将 TG Termes 字体替换为 TG TermesX 字体，与 \pkg{newtxmath} 宏包更适配，删除 \option{Scale} 选项。}
-% \changes{v3.2a}{0000/00/00}{英文字体三件套设置从 artpluscls 拆出至 fonts-artplus 模块}
+% \changes{v3.2a}{0000/00/00}{英文字体三件套设置从 artpluscls 拆出至 artplus-fonts 模块}
 %    \begin{macrocode}
-%</deps-artplus>
+%</artplus-deps>
 % ^^A ======================================================================
-% ^^A Module fonts-artplus: 正文字号、中英文主字体与字号宏命令（\wuhao 等）（artplus）
+% ^^A Module artplus-fonts: 正文字号、中英文主字体与字号宏命令（\wuhao 等）（artplus）
 % ^^A ======================================================================
-%<*fonts-artplus>
+%<*artplus-fonts>
 \ProvidesPackage{hithesisartplus-fonts}[0000/00/00 v3.2a hithesis-artplus fonts]
 \setmainfont{TeXGyreTermesX}[
   UprightFont = *-Regular ,
@@ -3434,8 +3434,8 @@ delim_1 "\\hspace*{\\fill}"
 \hit@def@fontsize{xiaoliu}{6.5bp}
 \hit@def@fontsize{qihao}{5.5bp}
 \hit@def@fontsize{bahao}{5bp}
-%</fonts-artplus>
-%<*deps-artplus>
+%</artplus-fonts>
+%<*artplus-deps>
 
 \RequirePackage{graphicx}
 \RequirePackage{pdfpages}
@@ -3468,14 +3468,14 @@ delim_1 "\\hspace*{\\fill}"
 
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{natbib/hyperref/url 配置从 deps-artplus 拆出至 hyperlink-artplus 模块（对齐 hyperlink-book/-art）}
+% \changes{v3.2a}{0000/00/00}{natbib/hyperref/url 配置从 artplus-deps 拆出至 artplus-hyperlink 模块（对齐 book-hyperlink/-art）}
 %    \begin{macrocode}
 \RequirePackage{hithesisartplus-hyperlink}
-%</deps-artplus>
+%</artplus-deps>
 % ^^A ======================================================================
-% ^^A Module hyperlink-artplus: hyperref/url 配置（PDF 书签、链接颜色）（artplus）
+% ^^A Module artplus-hyperlink: hyperref/url 配置（PDF 书签、链接颜色）（artplus）
 % ^^A ======================================================================
-%<*hyperlink-artplus>
+%<*artplus-hyperlink>
 \ProvidesPackage{hithesisartplus-hyperlink}[0000/00/00 v3.2a hithesis-artplus hyperlink]
 \RequirePackage[sort&compress,numbers]{natbib}
 \RequirePackage{hyperref}
@@ -3491,19 +3491,19 @@ delim_1 "\\hspace*{\\fill}"
   pdfborder=0 0 0
 }
 \urlstyle{same}
-%</hyperlink-artplus>
-%<*deps-artplus>
+%</artplus-hyperlink>
+%<*artplus-deps>
 
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{geometry 配置从 deps-artplus 拆出至 geometry-artplus 模块（对齐 geometry-book/-art）}
+% \changes{v3.2a}{0000/00/00}{geometry 配置从 artplus-deps 拆出至 artplus-geometry 模块（对齐 book-geometry/-art）}
 %    \begin{macrocode}
 \RequirePackage{hithesisartplus-geometry}
-%</deps-artplus>
+%</artplus-deps>
 % ^^A ======================================================================
-% ^^A Module geometry-artplus: 版芯尺寸与页边距（artplus）
+% ^^A Module artplus-geometry: 版芯尺寸与页边距（artplus）
 % ^^A ======================================================================
-%<*geometry-artplus>
+%<*artplus-geometry>
 \ProvidesPackage{hithesisartplus-geometry}[0000/00/00 v3.2a hithesis-artplus geometry]
 \RequirePackage{geometry}
 \geometry{%根据PlutoThesis 原版定义而来
@@ -3519,8 +3519,8 @@ delim_1 "\\hspace*{\\fill}"
   footskip=0true mm,
   foot=5.2true mm
 }
-%</geometry-artplus>
-%<*deps-artplus>
+%</artplus-geometry>
+%<*artplus-deps>
 
 \RequirePackage{tikzpagenodes}
 \RequirePackage{eso-pic}
@@ -3546,18 +3546,18 @@ delim_1 "\\hspace*{\\fill}"
 %
 % 添加字号、行距等设置
 %    \begin{macrocode}
-%</deps-artplus>
-%<*deps-artplus>
+%</artplus-deps>
+%<*artplus-deps>
 %    \end{macrocode}
 %
 % 进行字号、行距等设置
-% \changes{v3.2a}{0000/00/00}{章节标题格式从 artpluscls 拆出至 chapter-artplus 模块}
+% \changes{v3.2a}{0000/00/00}{章节标题格式从 artpluscls 拆出至 artplus-chapter 模块}
 %    \begin{macrocode}
-%</deps-artplus>
+%</artplus-deps>
 % ^^A ======================================================================
-% ^^A Module chapter-artplus: 章节标题格式（字号、缩进、间距、编号样式）（artplus）
+% ^^A Module artplus-chapter: 章节标题格式（字号、缩进、间距、编号样式）（artplus）
 % ^^A ======================================================================
-%<*chapter-artplus>
+%<*artplus-chapter>
 \ProvidesPackage{hithesisartplus-chapter}[0000/00/00 v3.2a hithesis-artplus chapter]
 \RequirePackage{xparse}
 \RequirePackage{tikz}
@@ -3610,17 +3610,17 @@ delim_1 "\\hspace*{\\fill}"
     {\hit@section[#2]{#3}}%
   }
 }
-%</chapter-artplus>
-%<*deps-artplus>
+%</artplus-chapter>
+%<*artplus-deps>
 %    \end{macrocode}
 %
 % 中文封面
 %    \begin{macrocode}
-%</deps-artplus>
+%</artplus-deps>
 % ^^A ======================================================================
-% ^^A Module meta-artplus: 元信息字段（\hitsetup 接受的 key）（artplus）
+% ^^A Module artplus-meta: 元信息字段（\hitsetup 接受的 key）（artplus）
 % ^^A ======================================================================
-%<*meta-artplus>
+%<*artplus-meta>
 \ProvidesPackage{hithesisartplus-meta}[0000/00/00 v3.2a hithesis-artplus meta]
 
 %% 中文封面
@@ -3661,13 +3661,13 @@ delim_1 "\\hspace*{\\fill}"
 }
 
 \def\hitsetup{\kvsetkeys{hit}}
-%</meta-artplus>
+%</artplus-meta>
 % ^^A ======================================================================
-% ^^A Module pagestyle-artplus: 页眉页脚样式（artplus）
+% ^^A Module artplus-pagestyle: 页眉页脚样式（artplus）
 % ^^A ======================================================================
-% \changes{v3.2a}{0000/00/00}{页眉页脚样式从 frontmatter-artplus 的 \cs{makecover} 内联提取到独立的 pagestyle-artplus 模块（对齐 pagestyle-book/-art）}
+% \changes{v3.2a}{0000/00/00}{页眉页脚样式从 artplus-frontmatter 的 \cs{makecover} 内联提取到独立的 artplus-pagestyle 模块（对齐 book-pagestyle/-art）}
 %    \begin{macrocode}
-%<*pagestyle-artplus>
+%<*artplus-pagestyle>
 \ProvidesPackage{hithesisartplus-pagestyle}[0000/00/00 v3.2a hithesis-artplus pagestyle]
 \RequirePackage{fancyhdr}
 \fancypagestyle{hit@artplus@main}{%
@@ -3676,13 +3676,13 @@ delim_1 "\\hspace*{\\fill}"
   \renewcommand{\footrulewidth}{0pt}%
   \fancyfoot[C]{\xiaowu-~\thepage~-}%
 }
-%</pagestyle-artplus>
+%</artplus-pagestyle>
 %    \end{macrocode}
 % ^^A ======================================================================
-% ^^A Module frontmatter-artplus: 封面与扉页（中英、本科、博士后等多版本）（artplus）
+% ^^A Module artplus-frontmatter: 封面与扉页（中英、本科、博士后等多版本）（artplus）
 % ^^A ======================================================================
 %    \begin{macrocode}
-%<*frontmatter-artplus>
+%<*artplus-frontmatter>
 \ProvidesPackage{hithesisartplus-frontmatter}[0000/00/00 v3.2a hithesis-artplus cover]
 
 \newcommand{\hit@report@titlepage@graduate}{
@@ -3734,19 +3734,19 @@ delim_1 "\\hspace*{\\fill}"
   }
   \pagestyle{hit@artplus@main}
 }
-%</frontmatter-artplus>
-%<*deps-artplus>
+%</artplus-frontmatter>
+%<*artplus-deps>
 %    \end{macrocode}
 %
 % 引用和参考文献格式
 % \changes{v3.2a}{0000/00/00}{设置参考文献列表标号的对齐方式}
-% \changes{v3.2a}{0000/00/00}{参考文献格式从 artpluscls 拆出至 bib-artplus 模块}
+% \changes{v3.2a}{0000/00/00}{参考文献格式从 artpluscls 拆出至 artplus-bib 模块}
 %    \begin{macrocode}
-%</deps-artplus>
+%</artplus-deps>
 % ^^A ======================================================================
-% ^^A Module bib-artplus: 参考文献加载与 natbib/gbt7714 设置（artplus）
+% ^^A Module artplus-bib: 参考文献加载与 natbib/gbt7714 设置（artplus）
 % ^^A ======================================================================
-%<*bib-artplus>
+%<*artplus-bib>
 \ProvidesPackage{hithesisartplus-bib}[0000/00/00 v3.2a hithesis-artplus bib]
 \RequirePackage[sort&compress,numbers]{natbib}
 \RequirePackage{xparse}
@@ -3810,7 +3810,7 @@ delim_1 "\\hspace*{\\fill}"
   \prg_break_point:
 }
 \ExplSyntaxOff
-%</bib-artplus>
+%</artplus-bib>
 %<*artpluscls>
 %    \end{macrocode}
 % 杂项
@@ -3837,9 +3837,9 @@ delim_1 "\\hspace*{\\fill}"
 \RequirePackage{hithesisart-options}
 %</artcls>
 % ^^A ======================================================================
-% ^^A Module options-art: 文档类选项的声明与后处理（type/campus/fontset 等）（art）
+% ^^A Module art-options: 文档类选项的声明与后处理（type/campus/fontset 等）（art）
 % ^^A ======================================================================
-%<*options-art>
+%<*art-options>
 \ProvidesPackage{hithesisart-options}[0000/00/00 v3.2a hithesis-art options]
 %    \end{macrocode}
 %
@@ -3966,7 +3966,7 @@ delim_1 "\\hspace*{\\fill}"
 \fi
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{选项后处理（AutoFakeBold 与 fontset 透传）从 artcls 移入 options-art 模块}
+% \changes{v3.2a}{0000/00/00}{选项后处理（AutoFakeBold 与 fontset 透传）从 artcls 移入 art-options 模块}
 %    \begin{macrocode}
 \RequirePackage{ifthen}
 \ifthenelse
@@ -3983,7 +3983,7 @@ delim_1 "\\hspace*{\\fill}"
   }%
   \PassOptionsToClass{fontset=\hit@fontset}{ctexart}
 }%
-%</options-art>
+%</art-options>
 %<*artcls>
 \LoadClass[a4paper,UTF8,zihao=-4,scheme=plain]{ctexart}
 %    \end{macrocode}
@@ -4001,14 +4001,14 @@ delim_1 "\\hspace*{\\fill}"
 \RequirePackage{hithesisart-toc}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{LoadClass 之后的所有标准包加载、配置整体打包至 deps-art 模块；artcls 仅保留 LoadClass 与早期模块加载}
-% \changes{v3.2a}{0000/00/00}{目录排版从 frontmatter-art 拆出至 toc-art 模块（对齐 book 家族的 toc-book）；在 deps-art 之后加载以避免 enumitem 覆盖 cft* 类长度}
+% \changes{v3.2a}{0000/00/00}{LoadClass 之后的所有标准包加载、配置整体打包至 art-deps 模块；artcls 仅保留 LoadClass 与早期模块加载}
+% \changes{v3.2a}{0000/00/00}{目录排版从 art-frontmatter 拆出至 art-toc 模块（对齐 book 家族的 book-toc）；在 art-deps 之后加载以避免 enumitem 覆盖 cft* 类长度}
 %    \begin{macrocode}
 %</artcls>
 % ^^A ======================================================================
-% ^^A Module deps-art: 第三方宏包集中加载与基础配置（含 hyperlink/geometry 内联）（art）
+% ^^A Module art-deps: 第三方宏包集中加载与基础配置（含 hyperlink/geometry 内联）（art）
 % ^^A ======================================================================
-%<*deps-art>
+%<*art-deps>
 \ProvidesPackage{hithesisart-deps}[0000/00/00 v3.2a hithesis-art deps]
 %    \end{macrocode}
 %
@@ -4032,13 +4032,13 @@ delim_1 "\\hspace*{\\fill}"
 % 删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG TermesX 与 TG Heros.
 % \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG Termes 与 TG Heros.}
 % \changes{v3.0.19}{2022/05/05}{将 TG Termes 字体替换为 TG TermesX 字体，与 \pkg{newtxmath} 宏包更适配，删除 \option{Scale} 选项。}
-% \changes{v3.2a}{0000/00/00}{英文字体三件套设置从 artcls 拆出至 fonts-art 模块}
+% \changes{v3.2a}{0000/00/00}{英文字体三件套设置从 artcls 拆出至 art-fonts 模块}
 %    \begin{macrocode}
-%</deps-art>
+%</art-deps>
 % ^^A ======================================================================
-% ^^A Module fonts-art: 正文字号、中英文主字体与字号宏命令（\wuhao 等）（art）
+% ^^A Module art-fonts: 正文字号、中英文主字体与字号宏命令（\wuhao 等）（art）
 % ^^A ======================================================================
-%<*fonts-art>
+%<*art-fonts>
 \ProvidesPackage{hithesisart-fonts}[0000/00/00 v3.2a hithesis-art fonts]
 \setmainfont{TeXGyreTermesX}[
   UprightFont = *-Regular ,
@@ -4099,8 +4099,8 @@ delim_1 "\\hspace*{\\fill}"
 \hit@def@fontsize{xiaoliu}{6.5bp}
 \hit@def@fontsize{qihao}{5.5bp}
 \hit@def@fontsize{bahao}{5bp}
-%</fonts-art>
-%<*deps-art>
+%</art-fonts>
+%<*art-deps>
 %    \end{macrocode}
 %
 % 单独使用 \pkg{newtxmath} 宏包改变数学字体时，会使 \texttt{operators}，\cs{mathrm}，\cs{mathit}，\cs{mathbf} 命令使用 CM 字体，根据 \href{https://github.com/sjtug/SJTUThesis/blob/b164d0f5b3087ed86c1038b5a85014b47a92c6f2/texmf/tex/latex/sjtuthesis/fd/sjtu-math-font-termes.def#L52-L65}{SJTUThesis 的字体设置} 进行调整
@@ -4165,14 +4165,14 @@ delim_1 "\\hspace*{\\fill}"
 
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{natbib/hyperref/url 配置从 deps-art 拆出至 hyperlink-art 模块（对齐 hyperlink-book）}
+% \changes{v3.2a}{0000/00/00}{natbib/hyperref/url 配置从 art-deps 拆出至 art-hyperlink 模块（对齐 book-hyperlink）}
 %    \begin{macrocode}
 \RequirePackage{hithesisart-hyperlink}
-%</deps-art>
+%</art-deps>
 % ^^A ======================================================================
-% ^^A Module hyperlink-art: hyperref/url 配置（PDF 书签、链接颜色）（art）
+% ^^A Module art-hyperlink: hyperref/url 配置（PDF 书签、链接颜色）（art）
 % ^^A ======================================================================
-%<*hyperlink-art>
+%<*art-hyperlink>
 \ProvidesPackage{hithesisart-hyperlink}[0000/00/00 v3.2a hithesis-art hyperlink]
 \RequirePackage[sort&compress,numbers]{natbib}
 \RequirePackage{hyperref}
@@ -4188,19 +4188,19 @@ delim_1 "\\hspace*{\\fill}"
   pdfborder=0 0 0
 }
 \urlstyle{same}
-%</hyperlink-art>
-%<*deps-art>
+%</art-hyperlink>
+%<*art-deps>
 
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{geometry 配置从 deps-art 拆出至 geometry-art 模块（对齐 geometry-book）}
+% \changes{v3.2a}{0000/00/00}{geometry 配置从 art-deps 拆出至 art-geometry 模块（对齐 book-geometry）}
 %    \begin{macrocode}
 \RequirePackage{hithesisart-geometry}
-%</deps-art>
+%</art-deps>
 % ^^A ======================================================================
-% ^^A Module geometry-art: 版芯尺寸与页边距（art）
+% ^^A Module art-geometry: 版芯尺寸与页边距（art）
 % ^^A ======================================================================
-%<*geometry-art>
+%<*art-geometry>
 \ProvidesPackage{hithesisart-geometry}[0000/00/00 v3.2a hithesis-art geometry]
 \ifhit@debug
   \RequirePackage[showframe]{geometry}
@@ -4227,8 +4227,8 @@ delim_1 "\\hspace*{\\fill}"
     \fi
   }
   {}
-%</geometry-art>
-%<*deps-art>
+%</art-geometry>
+%<*art-deps>
 
 \ifhit@debug
   \RequirePackage{layout}
@@ -4255,15 +4255,15 @@ delim_1 "\\hspace*{\\fill}"
 %    \begin{macrocode}
 %    \end{macrocode}
 % \changes{v3.1d}{2025/03/03}{将深圳校区硕士中期报告图注实现为“图 1-1 标题”的格式}
-% \changes{v3.2a}{0000/00/00}{图注/表注编号条件块从 artcls 拆出至 floats-art 模块}
+% \changes{v3.2a}{0000/00/00}{图注/表注编号条件块从 artcls 拆出至 art-floats 模块}
 %    \begin{macrocode}
-%</deps-art>
+%</art-deps>
 % ^^A ======================================================================
-% ^^A Module floats-art: 浮动体默认行为与双语题注（art）
+% ^^A Module art-floats: 浮动体默认行为与双语题注（art）
 % ^^A ======================================================================
-%<*floats-art>
+%<*art-floats>
 \ProvidesPackage{hithesisart-floats}[0000/00/00 v3.2a hithesis-art floats]
-% \changes{v3.2a}{0000/00/00}{floats-art 自包含 etoolbox 依赖以使用 \cs{ifboolexpr}}
+% \changes{v3.2a}{0000/00/00}{art-floats 自包含 etoolbox 依赖以使用 \cs{ifboolexpr}}
 \RequirePackage{etoolbox}
 \ifboolexpr{bool {hit@shenzhen} and bool {hit@master} and bool {hit@midterm}}{%将图注实现为“图 1-1 标题”的格式
   \RequirePackage{caption}
@@ -4285,14 +4285,14 @@ delim_1 "\\hspace*{\\fill}"
   \@addtoreset{table}{section}
   \@addtoreset{equation}{section}
 }{}
-%</floats-art>
-%<*deps-art>
+%</art-floats>
+%<*art-deps>
 %    \end{macrocode}
 %
 % 添加字号、行距等设置
 %    \begin{macrocode}
-%</deps-art>
-%<*deps-art>
+%</art-deps>
+%<*art-deps>
 %    \end{macrocode}
 %
 % 更改哈尔滨校区博士硕士开题节标题为小三号字体
@@ -4307,13 +4307,13 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %
 % \changes{v3.1d}{2025/03/03}{增加 \cs{parindent} 的值。\issue[201]}
-% \changes{v3.2a}{0000/00/00}{章节标题格式从 artcls 拆出至 chapter-art 模块}
+% \changes{v3.2a}{0000/00/00}{章节标题格式从 artcls 拆出至 art-chapter 模块}
 %    \begin{macrocode}
-%</deps-art>
+%</art-deps>
 % ^^A ======================================================================
-% ^^A Module chapter-art: 章节标题格式（字号、缩进、间距、编号样式）（art）
+% ^^A Module art-chapter: 章节标题格式（字号、缩进、间距、编号样式）（art）
 % ^^A ======================================================================
-%<*chapter-art>
+%<*art-chapter>
 \ProvidesPackage{hithesisart-chapter}[0000/00/00 v3.2a hithesis-art chapter]
 \RequirePackage{etoolbox}
 \setlength{\parindent}{2\ccwd}
@@ -4388,18 +4388,18 @@ delim_1 "\\hspace*{\\fill}"
     }
   }
 }{}
-%</chapter-art>
+%</art-chapter>
 % ^^A ======================================================================
-% ^^A Module pagestyle-art: 页眉页脚样式（fancyhdr 配置）（art）
+% ^^A Module art-pagestyle: 页眉页脚样式（fancyhdr 配置）（art）
 % ^^A ======================================================================
-%<*pagestyle-art>
+%<*art-pagestyle>
 \ProvidesPackage{hithesisart-pagestyle}[0000/00/00 v3.2a hithesis-art pagestyle]
-% \changes{v3.2a}{0000/00/00}{pagestyle-art 自包含 etoolbox 与 fancyhdr 依赖}
+% \changes{v3.2a}{0000/00/00}{art-pagestyle 自包含 etoolbox 与 fancyhdr 依赖}
 \RequirePackage{etoolbox}
 \RequirePackage{fancyhdr}
 %    \end{macrocode}
 % \changes{v3.1d}{2025/03/03}{为威海校区硕士开题设置章节样式与页眉页脚样式。\issue[219]}
-% \changes{v3.2a}{0000/00/00}{威海硕士开题的页眉定义放入 pagestyle-art，激活仍留 artcls 保持时序}
+% \changes{v3.2a}{0000/00/00}{威海硕士开题的页眉定义放入 art-pagestyle，激活仍留 artcls 保持时序}
 %    \begin{macrocode}
 \ifboolexpr{bool {hit@weihai} and bool {hit@master} and bool {hit@opening}}
   {
@@ -4441,8 +4441,8 @@ delim_1 "\\hspace*{\\fill}"
     \fancyhead[C]{\songti\xiaowu[0]哈尔滨工业大学（深圳）硕士学位论文开题报告}
   }
 }{}
-%</pagestyle-art>
-%<*deps-art>
+%</art-pagestyle>
+%<*art-deps>
 \ifboolexpr{bool {hit@weihai} and bool {hit@master} and bool {hit@opening}}
   {
     \pagestyle{hit@weihai@headings@main}
@@ -4454,10 +4454,10 @@ delim_1 "\\hspace*{\\fill}"
 % \changes{v3.1c}{2023/04/16}{深圳校区硕士中期不换页}
 % 为深圳校区硕士中期设置章节样式与页眉页脚样式。%
 % \changes{v3.1d}{2025/03/03}{根据 \issue[228] 更新深圳硕士中期节标题字号和间距}
-% \changes{v3.2a}{0000/00/00}{深圳硕士的 ctexset 与 fancypagestyle 被拆为两个独立条件块，分别放入 chapter-art 与 artcls，保持行为等价}
+% \changes{v3.2a}{0000/00/00}{深圳硕士的 ctexset 与 fancypagestyle 被拆为两个独立条件块，分别放入 art-chapter 与 artcls，保持行为等价}
 %    \begin{macrocode}
-%</deps-art>
-%<*deps-art>
+%</art-deps>
+%<*art-deps>
 %    \end{macrocode}
 
 %  \changes{v3.1d}{2025/03/03}{目录格式将在下文中设置}
@@ -4467,11 +4467,11 @@ delim_1 "\\hspace*{\\fill}"
 %
 % 中文封面
 %    \begin{macrocode}
-%</deps-art>
+%</art-deps>
 % ^^A ======================================================================
-% ^^A Module meta-art: 元信息字段（\hitsetup 接受的 key）（art）
+% ^^A Module art-meta: 元信息字段（\hitsetup 接受的 key）（art）
 % ^^A ======================================================================
-%<*meta-art>
+%<*art-meta>
 \ProvidesPackage{hithesisart-meta}[0000/00/00 v3.2a hithesis-art meta]
 %% 中文封面
 \def\hit@def@term#1{%
@@ -4508,11 +4508,11 @@ delim_1 "\\hspace*{\\fill}"
 }
 
 \def\hitsetup{\kvsetkeys{hit}}
-%</meta-art>
+%</art-meta>
 % ^^A ======================================================================
-% ^^A Module frontmatter-art: 封面与扉页（中英、本科、博士后等多版本）（art）
+% ^^A Module art-frontmatter: 封面与扉页（中英、本科、博士后等多版本）（art）
 % ^^A ======================================================================
-%<*frontmatter-art>
+%<*art-frontmatter>
 \ProvidesPackage{hithesisart-frontmatter}[0000/00/00 v3.2a hithesis-art cover]
 
 \newcommand{\hit@report@titlepage@graduate}{
@@ -4678,14 +4678,14 @@ delim_1 "\\hspace*{\\fill}"
 % \changes{v3.1c}{2023/04/16}{深圳校区硕士开题目录修改样式。}
 % \changes{v3.1c}{2023/04/16}{深圳校区硕士中期目录修改样式。\issue[166]}
 % \changes{v3.1d}{2025/03/03}{威海校区硕士开题目录修改样式。\issue[219]}
-% \changes{v3.2a}{0000/00/00}{目录排版从 frontmatter-art 拆出至独立模块 toc-art（对齐 toc-book）}
+% \changes{v3.2a}{0000/00/00}{目录排版从 art-frontmatter 拆出至独立模块 art-toc（对齐 book-toc）}
 % 深圳校区中期模板目录中一级标题为黑体 \cs{heiti}。\par
 % 深圳校区硕士开题目录有标题。
 % 深圳校区硕士中期目录也有标题。
 % 用 \pkg{tocloft} 宏包实现深圳校区硕士开题和中期的目录，逐步进行迁移。
 %    \begin{macrocode}
-%</frontmatter-art>
-%<*toc-art>
+%</art-frontmatter>
+%<*art-toc>
 \ProvidesPackage{hithesisart-toc}[0000/00/00 v3.2a hithesis-art toc]
 \ExplSyntaxOn
 %\ifboolexpr{ {bool {hit@shenzhen} or bool {hit@weihai}} and bool {hit@master} }{
@@ -4740,8 +4740,8 @@ delim_1 "\\hspace*{\\fill}"
   %     \normalsize\@starttoc{toc}
   %   }
 %}
-%</toc-art>
-%<*frontmatter-art>
+%</art-toc>
+%<*art-frontmatter>
 %    \end{macrocode}
 % \begin{macro}{\makecover}
 %    \begin{macrocode}
@@ -4774,18 +4774,18 @@ delim_1 "\\hspace*{\\fill}"
   \clearpage
   \hit@report@backpage@bachelor
 }
-%</frontmatter-art>
-%<*deps-art>
+%</art-frontmatter>
+%<*art-deps>
 %    \end{macrocode}
 % \end{macro}
 % 引用和参考文献格式
-% \changes{v3.2a}{0000/00/00}{参考文献格式从 artcls 拆出至 bib-art 模块}
+% \changes{v3.2a}{0000/00/00}{参考文献格式从 artcls 拆出至 art-bib 模块}
 %    \begin{macrocode}
-%</deps-art>
+%</art-deps>
 % ^^A ======================================================================
-% ^^A Module bib-art: 参考文献加载与 natbib/gbt7714 设置（art）
+% ^^A Module art-bib: 参考文献加载与 natbib/gbt7714 设置（art）
 % ^^A ======================================================================
-%<*bib-art>
+%<*art-bib>
 \ProvidesPackage{hithesisart-bib}[0000/00/00 v3.2a hithesis-art bib]
 \RequirePackage[sort&compress,numbers]{natbib}
 \RequirePackage{etoolbox}
@@ -4862,7 +4862,7 @@ delim_1 "\\hspace*{\\fill}"
   \prg_break_point:
 }
 \ExplSyntaxOff
-%</bib-art>
+%</art-bib>
 %<*artcls>
 %    \end{macrocode}
 % 杂项
@@ -4889,9 +4889,9 @@ delim_1 "\\hspace*{\\fill}"
 \RequirePackage{hithesisbook-options}
 %</bookcls>
 % ^^A ======================================================================
-% ^^A Module options-book: 文档类选项的声明与后处理（type/campus/fontset 等）（book）
+% ^^A Module book-options: 文档类选项的声明与后处理（type/campus/fontset 等）（book）
 % ^^A ======================================================================
-%<*options-book>
+%<*book-options>
 \ProvidesPackage{hithesisbook-options}[0000/00/00 v3.2a hithesis-book options]
 %    \end{macrocode}
 %
@@ -5187,7 +5187,7 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %
 % \changes{v3.2a}{0000/00/00}{深圳校区本科现在直接指向本部本科模板，旧深圳本科模板代码暂时保留}
-% \changes{v3.2a}{0000/00/00}{选项后处理（shenzhen重定向、type校验、PassOptions、fontset/zijv/geometrynew 默认）从 bookcls 移入 options-book，cls 只保留 LoadClass 与模块加载}
+% \changes{v3.2a}{0000/00/00}{选项后处理（shenzhen重定向、type校验、PassOptions、fontset/zijv/geometrynew 默认）从 bookcls 移入 book-options，cls 只保留 LoadClass 与模块加载}
 % 深圳校区本科现在直接指向本部本科模板，旧深圳本科模板代码暂时保留。
 %    \begin{macrocode}
 \ifhit@shenzhen
@@ -5279,7 +5279,7 @@ delim_1 "\\hspace*{\\fill}"
     \fi
   \fi
 \fi
-%</options-book>
+%</book-options>
 %<*bookcls>
 %    \end{macrocode}
 %
@@ -5302,7 +5302,7 @@ delim_1 "\\hspace*{\\fill}"
 \RequirePackage{hithesisbook-mainmatter}
 \RequirePackage{hithesisbook-paragraph}
 \RequirePackage{hithesisbook-footnote}
-%% math-book 与 floats-book 互不依赖（ntheorem 由 deps-book 提供），
+%% book-math 与 book-floats 互不依赖（ntheorem 由 book-deps 提供），
 %% 此处加载顺序无约束。
 \RequirePackage{hithesisbook-math}
 \RequirePackage{hithesisbook-floats}
@@ -5311,13 +5311,13 @@ delim_1 "\\hspace*{\\fill}"
 \AtEndOfClass{\sloppy}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{重组 bookcls 加载框架：deps-book 仅保留第三方依赖与 hyperlink/geometry 基础设施，晚加载功能模块（glossary/mainmatter/paragraph/footnote/math/floats/toc）提升至 cls；misc-book 模块合并为 cls 内联钩子}
+% \changes{v3.2a}{0000/00/00}{重组 bookcls 加载框架：book-deps 仅保留第三方依赖与 hyperlink/geometry 基础设施，晚加载功能模块（glossary/mainmatter/paragraph/footnote/math/floats/toc）提升至 cls；misc-book 模块合并为 cls 内联钩子}
 %    \begin{macrocode}
 %</bookcls>
 % ^^A ======================================================================
-% ^^A Module deps-book: 第三方宏包集中加载与基础配置（含 hyperlink/geometry 内联）（book）
+% ^^A Module book-deps: 第三方宏包集中加载与基础配置（含 hyperlink/geometry 内联）（book）
 % ^^A ======================================================================
-%<*deps-book>
+%<*book-deps>
 \ProvidesPackage{hithesisbook-deps}[0000/00/00 v3.2a hithesis-book deps]
 %
 %
@@ -5349,13 +5349,13 @@ delim_1 "\\hspace*{\\fill}"
 % 删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG TermesX 与 TG Heros.
 % \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG Termes 与 TG Heros.}
 % \changes{v3.0.19}{2022/05/05}{将 TG Termes 字体替换为 TG TermesX 字体，与 \pkg{newtxmath} 宏包更适配，删除 \option{Scale} 选项。}
-% \changes{v3.2a}{0000/00/00}{英文字体三件套设置从 bookcls 拆出至 fonts-book 模块（与 fonts-art / fonts-artplus 保持一致）}
+% \changes{v3.2a}{0000/00/00}{英文字体三件套设置从 bookcls 拆出至 book-fonts 模块（与 art-fonts / artplus-fonts 保持一致）}
 %    \begin{macrocode}
-%</deps-book>
+%</book-deps>
 % ^^A ======================================================================
-% ^^A Module fonts-book: 正文字号、中英文主字体与字号宏命令（\wuhao 等）（book）
+% ^^A Module book-fonts: 正文字号、中英文主字体与字号宏命令（\wuhao 等）（book）
 % ^^A ======================================================================
-%<*fonts-book>
+%<*book-fonts>
 \ProvidesPackage{hithesisbook-fonts}[0000/00/00 v3.2a hithesis-book fonts]
 \setmainfont{TeXGyreTermesX}[
   UprightFont = *-Regular ,
@@ -5383,8 +5383,8 @@ delim_1 "\\hspace*{\\fill}"
   BoldItalicFont = *-bolditalic ,
   Extension = .otf ,
 ]
-%</fonts-book>
-%<*deps-book>
+%</book-fonts>
+%<*book-deps>
 %    \end{macrocode}
 %
 % 单独使用 \pkg{newtxmath} 宏包改变数学字体时，会使 \texttt{operators}，\cs{mathrm}，\cs{mathit}，\cs{mathbf} 命令使用 CM 字体，根据 \href{https://github.com/sjtug/SJTUThesis/blob/b164d0f5b3087ed86c1038b5a85014b47a92c6f2/texmf/tex/latex/sjtuthesis/fd/sjtu-math-font-termes.def#L52-L65}{SJTUThesis 的字体设置} 进行调整
@@ -5416,7 +5416,7 @@ delim_1 "\\hspace*{\\fill}"
 \RequirePackage{graphicx}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的 xcolor、tikz 与全局颜色主题并入 deps-book，作为彩色与图形基础宏包}
+% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的 xcolor、tikz 与全局颜色主题并入 book-deps，作为彩色与图形基础宏包}
 % 彩色支持与 \pkg{tikz}（封面与正文图形需要），并预定义全局颜色主题。
 %    \begin{macrocode}
 \RequirePackage{xcolor}
@@ -5489,13 +5489,13 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %
 % 生成有书签的 pdf 及其开关，请结合 gbk2uni 避免书签乱码。
-% \changes{v3.2a}{0000/00/00}{hyperref/url/gbt7714/citetwocomma 等链接与引用配置从 bookcls 拆出至 hyperlink-book 模块}
+% \changes{v3.2a}{0000/00/00}{hyperref/url/gbt7714/citetwocomma 等链接与引用配置从 bookcls 拆出至 book-hyperlink 模块}
 %    \begin{macrocode}
-%</deps-book>
+%</book-deps>
 % ^^A ======================================================================
-% ^^A Module hyperlink-book: hyperref/url 配置（PDF 书签、链接颜色）（book）
+% ^^A Module book-hyperlink: hyperref/url 配置（PDF 书签、链接颜色）（book）
 % ^^A ======================================================================
-%<*hyperlink-book>
+%<*book-hyperlink>
 \ProvidesPackage{hithesisbook-hyperlink}[0000/00/00 v3.2a hithesis-book hyperlink]
 \RequirePackage{hyperref}
 \hypersetup{%
@@ -5533,8 +5533,8 @@ delim_1 "\\hspace*{\\fill}"
   {\typeout{Use comma between neighboring citations}}%
   {\ClassError{hithesisbook}{fail to patch \NAT@citexnum}{}}%
 \fi
-%</hyperlink-book>
-%<*deps-book>
+%</book-hyperlink>
+%<*book-deps>
 \RequirePackage{hithesisbook-hyperlink}
 %    \end{macrocode}
 %
@@ -5542,13 +5542,13 @@ delim_1 "\\hspace*{\\fill}"
 % \label{sec:layout}
 % 本来这部分应该是最容易设置的，但根据我工\PGR\ 的3.8,3.4,3.2节的版芯矛盾，此处
 % 设置两种版芯。
-% \changes{v3.2a}{0000/00/00}{页面 geometry 设置从 bookcls 拆出至 geometry-book 模块}
+% \changes{v3.2a}{0000/00/00}{页面 geometry 设置从 bookcls 拆出至 book-geometry 模块}
 %    \begin{macrocode}
-%</deps-book>
+%</book-deps>
 % ^^A ======================================================================
-% ^^A Module geometry-book: 版芯尺寸与页边距（book）
+% ^^A Module book-geometry: 版芯尺寸与页边距（book）
 % ^^A ======================================================================
-%<*geometry-book>
+%<*book-geometry>
 \ProvidesPackage{hithesisbook-geometry}[0000/00/00 v3.2a hithesis-book geometry]
 \ifhit@debug\RequirePackage[showframe]{geometry}\else\RequirePackage{geometry}\fi
 \geometry{%根据PlutoThesis 原版定义而来
@@ -5606,8 +5606,8 @@ delim_1 "\\hspace*{\\fill}"
   bottom=28.8true mm
   }
 \fi\fi
-%</geometry-book>
-%<*deps-book>
+%</book-geometry>
+%<*book-deps>
 \RequirePackage{hithesisbook-geometry}
 %    \end{macrocode}
 %
@@ -5658,19 +5658,19 @@ delim_1 "\\hspace*{\\fill}"
 % 排版logo。
 % \changes{v3.0.21}{2022/05/11}{删除 \pkg{xltxtra} 宏包, 来实现规范样式的上标。\issue[125]}
 %    \begin{macrocode}
-%</deps-book>
+%</book-deps>
 %    \end{macrocode}
 %
 % \subsection{主文档格式}
 % \label{sec:mainbody}
 %
 % \subsubsection{Three matters}
-% \changes{v3.2a}{0000/00/00}{glossaries 与 frontmatter/mainmatter/backmatter 等设置从 bookcls 拆出至 glossary-book 与 mainmatter-book 模块}
+% \changes{v3.2a}{0000/00/00}{glossaries 与 frontmatter/mainmatter/backmatter 等设置从 bookcls 拆出至 book-glossary 与 book-mainmatter 模块}
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module glossary-book: 术语与符号表（glossaries 配置 + 示例条目）（book）
+% ^^A Module book-glossary: 术语与符号表（glossaries 配置 + 示例条目）（book）
 % ^^A ======================================================================
-%<*glossary-book>
+%<*book-glossary>
 \ProvidesPackage{hithesisbook-glossary}[0000/00/00 v3.2a hithesis-book glossary]
 \ifhit@english
 %    \end{macrocode}
@@ -5700,7 +5700,7 @@ delim_1 "\\hspace*{\\fill}"
 \fi
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的示例术语表条目与中文术语辅助宏（\cs{gtssbp}、\cs{gscna}、\cs{gscnas}）并入 glossary-book}
+% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的示例术语表条目与中文术语辅助宏（\cs{gtssbp}、\cs{gscna}、\cs{gscnas}）并入 book-glossary}
 % 示例术语表条目（首次出现展开为全称，之后缩写），以及中文术语的双语索引辅助宏。
 %    \begin{macrocode}
 \newacronym{etssbp}{TSSBP}{Tree-structured Stick-breaking process}
@@ -5713,11 +5713,11 @@ delim_1 "\\hspace*{\\fill}"
 \newacronym[shortplural=SCNAs,longplural={体细胞拷贝数变异（Somatic copy number alternation，SCNA）}]{scna}{SCNA}{体细胞拷贝数变异（Somatic copy number alternation，SCNA）}
 \def\gscna{\gls{scna}\sindex[china]{ti!体细胞拷贝数变异}\sindex[english]{Somatic copy number alternation}\ignorespaces}
 \def\gscnas{\glspl{scna}\sindex[china]{ti!体细胞拷贝数变异}\sindex[english]{Somatic copy number alternation}\ignorespaces}
-%</glossary-book>
+%</book-glossary>
 % ^^A ======================================================================
-% ^^A Module mainmatter-book: 正文与前后文切换（frontmatter/mainmatter/backmatter）（book）
+% ^^A Module book-mainmatter: 正文与前后文切换（frontmatter/mainmatter/backmatter）（book）
 % ^^A ======================================================================
-%<*mainmatter-book>
+%<*book-mainmatter>
 \ProvidesPackage{hithesisbook-mainmatter}[0000/00/00 v3.2a hithesis-book mainmatter]
 %    \end{macrocode}
 % \begin{macro}{\cleardoublepage}
@@ -5799,7 +5799,7 @@ delim_1 "\\hspace*{\\fill}"
 \renewcommand\backmatter{%
   \ifhit@openright\cleardoublepage\else\clearpage\fi
   \@mainmattertrue}
-%</mainmatter-book>
+%</book-mainmatter>
 %    \end{macrocode}
 %
 % \end{macro}
@@ -5809,7 +5809,7 @@ delim_1 "\\hspace*{\\fill}"
 % \begin{macro}{\normalsize}
 % 根据我工规定，正文小四号 (12bp) 字，行距为固定值3--4mm。
 %    \begin{macrocode}
-%<*fonts-book>
+%<*book-fonts>
 %    \end{macrocode}
 %
 % 1bp = 1/72 inch, 1 inch = 25.4 mm
@@ -5906,7 +5906,7 @@ delim_1 "\\hspace*{\\fill}"
 \hit@def@fontsize{xiaoliu}{6.5bp}
 \hit@def@fontsize{qihao}{5.5bp}
 \hit@def@fontsize{bahao}{5bp}
-%</fonts-book>
+%</book-fonts>
 %    \end{macrocode}
 %
 % \end{macro}
@@ -5944,9 +5944,9 @@ delim_1 "\\hspace*{\\fill}"
 % \end{itemize}
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module pagestyle-book: 页眉页脚样式（fancyhdr 配置）（book）
+% ^^A Module book-pagestyle: 页眉页脚样式（fancyhdr 配置）（book）
 % ^^A ======================================================================
-%<*pagestyle-book>
+%<*book-pagestyle>
 \ProvidesPackage{hithesisbook-pagestyle}[0000/00/00 v3.2a hithesis-book pagestyle]
 % \changes{v3.2a}{0000/00/00}{pagestyle 模块抽取后，fancyhdr 需提前加载}
 \RequirePackage{fancyhdr}
@@ -6122,7 +6122,7 @@ delim_1 "\\hspace*{\\fill}"
 \AtBeginDocument{%此处解决页眉经典bug
   \pagestyle{hit@empty}
   \renewcommand{\chaptermark}[1]{\@mkboth{\CTEXthechapter\enspace#1}{}}}
-%</pagestyle-book>
+%</book-pagestyle>
 %    \end{macrocode}
 %
 % \end{macro}
@@ -6133,12 +6133,12 @@ delim_1 "\\hspace*{\\fill}"
 % \label{sec:paragraph}
 %
 % 全文首行缩进 2 字符，标点符号用全角
-% \changes{v3.2a}{0000/00/00}{段落相关代码从 bookcls 拆出至 paragraph-book 模块}
+% \changes{v3.2a}{0000/00/00}{段落相关代码从 bookcls 拆出至 book-paragraph 模块}
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module paragraph-book: 段落首行缩进与标点处理（book）
+% ^^A Module book-paragraph: 段落首行缩进与标点处理（book）
 % ^^A ======================================================================
-%<*paragraph-book>
+%<*book-paragraph>
 \ProvidesPackage{hithesisbook-paragraph}[0000/00/00 v3.2a hithesis-book paragraph]
 \ctexset{%
   punct=quanjiao,
@@ -6151,7 +6151,7 @@ delim_1 "\\hspace*{\\fill}"
 \setlist{nosep}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{\cs{setitemize}/\cs{setenumerate}/\cs{setlength}\{\cs{parindent}\} 从 floats-book 迁入 paragraph-book（归位至段落/列表排版职责）}
+% \changes{v3.2a}{0000/00/00}{\cs{setitemize}/\cs{setenumerate}/\cs{setlength}\{\cs{parindent}\} 从 book-floats 迁入 book-paragraph（归位至段落/列表排版职责）}
 % 列表环境的全局间距设置；正文首行缩进。
 %    \begin{macrocode}
 \setitemize{leftmargin=0em,itemsep=0em,partopsep=0em,parsep=0em,topsep=0em,itemindent=3em}
@@ -6159,24 +6159,24 @@ delim_1 "\\hspace*{\\fill}"
 \setlength{\parindent}{2em}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{\cs{cmd}/\cs{cs} 排版命令名工具从 math-book 迁入 paragraph-book（归位至正文排版细节）}
+% \changes{v3.2a}{0000/00/00}{\cs{cmd}/\cs{cs} 排版命令名工具从 book-math 迁入 book-paragraph（归位至正文排版细节）}
 % 排版命令名的辅助：\cs{cs} 在文本中打印 \cs{name} 字面。
 %    \begin{macrocode}
 \def\cmd#1{\cs{\expandafter\cmd@to@cs\string#1}}
 \def\cmd@to@cs#1#2{\char\number`#2\relax}
 \DeclareRobustCommand\cs[1]{\texttt{\char`\\#1}}
-%</paragraph-book>
+%</book-paragraph>
 %    \end{macrocode}
 %
 % \subsubsection{脚注}
 % \label{sec:footnote}
 % 脚注符合中文习惯，数字带圈。
-% \changes{v3.2a}{0000/00/00}{脚注相关代码从 bookcls 拆出至 footnote-book 模块}
+% \changes{v3.2a}{0000/00/00}{脚注相关代码从 bookcls 拆出至 book-footnote 模块}
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module footnote-book: 脚注样式与编号（book）
+% ^^A Module book-footnote: 脚注样式与编号（book）
 % ^^A ======================================================================
-%<*footnote-book>
+%<*book-footnote>
 \ProvidesPackage{hithesisbook-footnote}[0000/00/00 v3.2a hithesis-book footnote]
 \def\hit@textcircled#1{%
   \ifnum\value{#1} >9
@@ -6207,22 +6207,22 @@ delim_1 "\\hspace*{\\fill}"
 \def\hit@@makefnmark{\hbox{{\normalfont\@thefnmark}}}
 \pretocmd{\@makefntext}{\let\@makefnmark\hit@@makefnmark}{}{}
 \apptocmd{\@makefntext}{\let\@makefnmark\hit@makefnmark}{}{}
-%</footnote-book>
+%</book-footnote>
 %    \end{macrocode}
 %
 % \subsubsection{数学相关}
 % \label{sec:equation}
 % 允许太长的公式断行、分页等。
-% \changes{v3.2a}{0000/00/00}{数学相关代码从 bookcls 拆出至 math-book 模块}
+% \changes{v3.2a}{0000/00/00}{数学相关代码从 bookcls 拆出至 book-math 模块}
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module math-book: 数学公式断行与定理样式（含 siunitx/bm/mathrsfs 等）（book）
+% ^^A Module book-math: 数学公式断行与定理样式（含 siunitx/bm/mathrsfs 等）（book）
 % ^^A ======================================================================
-%<*math-book>
+%<*book-math>
 \ProvidesPackage{hithesisbook-math}[0000/00/00 v3.2a hithesis-book math]
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的数学相关宏包与符号工具并入 math-book}
+% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的数学相关宏包与符号工具并入 book-math}
 % 根据窝工规范对数字书写的规定（4 位及以上每 3 位空 1/4 汉字），加载 \pkg{siunitx} 并配置分组分隔。
 % \pkg{bm} 处理数学公式中的黑斜体，\pkg{mathrsfs} 提供不同于 \cs{mathcal}/\cs{mathfrak} 的英文花体。
 %    \begin{macrocode}
@@ -6246,7 +6246,7 @@ delim_1 "\\hspace*{\\fill}"
 \newcommand{\theUndirectedEdge}[2]{{\overline{{#1}{#2}}}}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{\cs{cmd}/\cs{cs} 排版命令名工具从 math-book 迁出至 paragraph-book}
+% \changes{v3.2a}{0000/00/00}{\cs{cmd}/\cs{cs} 排版命令名工具从 book-math 迁出至 book-paragraph}
 % 以下为原模板的核心公式断行设置。
 %    \begin{macrocode}
 \allowdisplaybreaks[4]
@@ -6277,7 +6277,7 @@ delim_1 "\\hspace*{\\fill}"
 \renewcommand{\eqref}[1]{\textup{(\ref{#1})}}
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{ntheorem 全局样式（\cs{renewtheoremstyle}/\cs{theorembodyfont}/\cs{theoremheaderfont}/\cs{theoremsymbol}/\cs{theoremXXskipamount}）与 \cs{arraycolsep} 从 floats-book 迁入 math-book（归位至数学/定理职责）}
+% \changes{v3.2a}{0000/00/00}{ntheorem 全局样式（\cs{renewtheoremstyle}/\cs{theorembodyfont}/\cs{theoremheaderfont}/\cs{theoremsymbol}/\cs{theoremXXskipamount}）与 \cs{arraycolsep} 从 book-floats 迁入 book-math（归位至数学/定理职责）}
 % ntheorem 定理全局样式与公式数组列间距。
 %    \begin{macrocode}
 \renewtheoremstyle{plain}
@@ -6289,7 +6289,7 @@ delim_1 "\\hspace*{\\fill}"
 \setlength{\theorempreskipamount}{0pt}
 \setlength{\theorempostskipamount}{-2pt}
 \arraycolsep=1.6pt
-%</math-book>
+%</book-math>
 %    \end{macrocode}
 %
 % 定理标题使用黑体，正文使用宋体，冒号隔开。
@@ -6566,12 +6566,12 @@ delim_1 "\\hspace*{\\fill}"
 % 高度。
 % \changes{v1.0.09}{2018/01/07}{修正float垂直间距bug}
 % \changes{v2.0.09}{2019/06/24}{修正float垂直间距bug}
-% \changes{v3.2a}{0000/00/00}{浮动对象与表格代码从 bookcls 拆出至 floats-book 模块；在 cls 原位置加载以避免依赖错位}
+% \changes{v3.2a}{0000/00/00}{浮动对象与表格代码从 bookcls 拆出至 book-floats 模块；在 cls 原位置加载以避免依赖错位}
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module floats-book: 浮动体默认行为与双语题注（book）
+% ^^A Module book-floats: 浮动体默认行为与双语题注（book）
 % ^^A ======================================================================
-%<*floats-book>
+%<*book-floats>
 \ProvidesPackage{hithesisbook-floats}[0000/00/00 v3.2a hithesis-book floats]
 \ifhit@postdoc
 \setlength{\intextsep}{10.5bp}
@@ -6723,7 +6723,7 @@ delim_1 "\\hspace*{\\fill}"
 \renewcommand{\thetable}{\arabic{chapter}-\arabic{table}}%使表编号为 7-1 的格式
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{\cs{setitemize}/\cs{setenumerate} 从 floats-book 迁出至 paragraph-book}
+% \changes{v3.2a}{0000/00/00}{\cs{setitemize}/\cs{setenumerate} 从 book-floats 迁出至 book-paragraph}
 % 此处删除hang caption的设置
 % \changes{v1.0.06}{2017/10/25}{删除caption hang 的默认设置，因为不在规范要求中}
 %    \begin{macrocode}
@@ -6751,9 +6751,9 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %
 % \changes{v2.0.01}{2018/6/28}{去除定理注释括号}
-% \changes{v3.2a}{0000/00/00}{ntheorem 定理样式与 \cs{arraycolsep} 从 floats-book 迁出至 math-book；\cs{setlength}\{\cs{parindent}\}\{2em\} 迁出至 paragraph-book}
+% \changes{v3.2a}{0000/00/00}{ntheorem 定理样式与 \cs{arraycolsep} 从 book-floats 迁出至 book-math；\cs{setlength}\{\cs{parindent}\}\{2em\} 迁出至 book-paragraph}
 %
-% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的旋转/算法/代码段宏包并入 floats-book}
+% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的旋转/算法/代码段宏包并入 book-floats}
 % 旋转图表所需的 \pkg{rotating}。
 %    \begin{macrocode}
 \RequirePackage{rotating}
@@ -6803,7 +6803,7 @@ breaklines=true
 }
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的示例 tikz 样式与染色体示意图绘制宏并入 floats-book}
+% \changes{v3.2a}{0000/00/00}{原 hithesis.sty 中的示例 tikz 样式与染色体示意图绘制宏并入 book-floats}
 % 示例文档使用的 tikz 样式与染色体段落、细胞绘制宏。
 %    \begin{macrocode}
 \tikzset{maternal/.style={colorone}}
@@ -6981,7 +6981,7 @@ breaklines=true
   \draw (\x+6.5,\y-1) node[aallele]{C};
   \gsegr{\x+3.5}{3}{\y-1}{0.2}{0.5}{pseg}{0.5}{1.5}{paternal};
 }
-%</floats-book>
+%</book-floats>
 %    \end{macrocode}
 %
 % \subsubsection{章节标题}
@@ -7089,9 +7089,9 @@ breaklines=true
 % 按照我工要求，页面中标题之下不少于一行。
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module chapter-book: 章节标题格式（字号、缩进、间距、编号样式）（book）
+% ^^A Module book-chapter: 章节标题格式（字号、缩进、间距、编号样式）（book）
 % ^^A ======================================================================
-%<*chapter-book>
+%<*book-chapter>
 \ProvidesPackage{hithesisbook-chapter}[0000/00/00 v3.2a hithesis-book chapter]
 \def\hit@title@font{%
   \ifhit@arialtitle\sffamily\else\heiti\fi}
@@ -7557,11 +7557,11 @@ breaklines=true
 % 封面信息。
 % \changes{v1.0.11}{2018/03/07}{更改的中文标题，根据反馈，在封面中标题需要自由换行且不能影响到原创性声明。此处额外设置了一个变量ctitlecover。}
 %    \begin{macrocode}
-%</chapter-book>
+%</book-chapter>
 % ^^A ======================================================================
-% ^^A Module meta-book: 元信息字段（\hitsetup 接受的 key）（book）
+% ^^A Module book-meta: 元信息字段（\hitsetup 接受的 key）（book）
 % ^^A ======================================================================
-%<*meta-book>
+%<*book-meta>
 \ProvidesPackage{hithesisbook-meta}[0000/00/00 v3.2a hithesis-book meta]
 % \changes{v3.2a}{0000/00/00}{meta 模块抽取后，etoolbox 需提前加载以使用 \cs{AfterPreamble}}
 \RequirePackage{etoolbox}
@@ -7655,7 +7655,7 @@ breaklines=true
 \AfterPreamble{%
   \ifdefempty{\hit@firstpagecdate}{\firstpagecdate{\hit@cdate}}{}%
 }
-%</meta-book>
+%</book-meta>
 %    \end{macrocode}
 %
 %   定义封面中用到的词汇。
@@ -8091,9 +8091,9 @@ breaklines=true
 % 中英文封面。
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module frontmatter-book: 封面与扉页（中英、本科、博士后等多版本）（book）
+% ^^A Module book-frontmatter: 封面与扉页（中英、本科、博士后等多版本）（book）
 % ^^A ======================================================================
-%<*frontmatter-book>
+%<*book-frontmatter>
 \ProvidesPackage{hithesisbook-frontmatter}[0000/00/00 v3.2a hithesis-book cover]
 \newlength{\hit@title@width}
 \newcommand{\hit@put@title}[2][\hit@title@width]{%
@@ -8854,13 +8854,13 @@ breaklines=true
 % \subsubsection{目录}
 % \label{sec:toc}
 % 本科文科生要求目录有四级。
-% \changes{v3.2a}{0000/00/00}{目录相关代码从 bookcls 拆出至 toc-book 模块；模块加载点保留在原始位置以避免被后续包覆盖布局参数}
+% \changes{v3.2a}{0000/00/00}{目录相关代码从 bookcls 拆出至 book-toc 模块；模块加载点保留在原始位置以避免被后续包覆盖布局参数}
 %    \begin{macrocode}
-%</frontmatter-book>
+%</book-frontmatter>
 % ^^A ======================================================================
-% ^^A Module toc-book: 目录格式（book）
+% ^^A Module book-toc: 目录格式（book）
 % ^^A ======================================================================
-%<*toc-book>
+%<*book-toc>
 \ProvidesPackage{hithesisbook-toc}[0000/00/00 v3.2a hithesis-book toc]
 \setcounter{secnumdepth}{3}
 \setcounter{tocdepth}{2}
@@ -9010,17 +9010,17 @@ breaklines=true
 }
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{附录、结论、致谢、声明、答辩决议等环境从 bookcls 拆出至 appendix-book 模块}
+% \changes{v3.2a}{0000/00/00}{附录、结论、致谢、声明、答辩决议等环境从 bookcls 拆出至 book-appendix 模块}
 % 设置附录、结论、参考文献等格式。
 %    \begin{macro}{\hit@engtoc@chapapp}
 % \changes{v3.1b}{2022/06/06}{添加 \cs{hit@engtoc@chapapp} 来使英文目录中的附录为 “Appendix”。}
 % \cs{hit@engtoc@chapapp} 命令在英文目录正文显示为 “Chapter”， 在附录部分显示为 “Appendix”。
 %    \begin{macrocode}
-%</toc-book>
+%</book-toc>
 % ^^A ======================================================================
-% ^^A Module appendix-book: 附录环境（book）
+% ^^A Module book-appendix: 附录环境（book）
 % ^^A ======================================================================
-%<*appendix-book>
+%<*book-appendix>
 \ProvidesPackage{hithesisbook-appendix}[0000/00/00 v3.2a hithesis-book appendix]
 \RequirePackage{enumitem}
 \RequirePackage{xparse}
@@ -9282,15 +9282,15 @@ breaklines=true
   }%
 }{}
 }
-%</appendix-book>
+%</book-appendix>
 %    \end{macrocode}
 %    \end{macro}
-% \changes{v3.2a}{0000/00/00}{参考文献相关代码从 bookcls 拆出至 bib-book 模块}
+% \changes{v3.2a}{0000/00/00}{参考文献相关代码从 bookcls 拆出至 book-bib 模块}
 %    \begin{macrocode}
 % ^^A ======================================================================
-% ^^A Module bib-book: 参考文献加载与 natbib/gbt7714 设置（book）
+% ^^A Module book-bib: 参考文献加载与 natbib/gbt7714 设置（book）
 % ^^A ======================================================================
-%<*bib-book>
+%<*book-bib>
 \ProvidesPackage{hithesisbook-bib}[0000/00/00 v3.2a hithesis-book bib]
 \RequirePackage[sort&compress]{gbt7714}
 \RequirePackage{etoolbox}
@@ -9441,11 +9441,11 @@ breaklines=true
 \ExplSyntaxOff
 %    \end{macrocode}
 %
-% \changes{v3.2a}{0000/00/00}{\cs{citeup}（上标引用宏）从 floats-book 迁入 bib-book，归位至引用语义所属模块}
+% \changes{v3.2a}{0000/00/00}{\cs{citeup}（上标引用宏）从 book-floats 迁入 book-bib，归位至引用语义所属模块}
 % 上标引用宏 \cs{citeup}（语义属引用,非浮动体）。
 %    \begin{macrocode}
 \newcommand{\citeup}[1]{\textsuperscript{\cite{#1}}}
-%</bib-book>
+%</book-bib>
 %    \end{macrocode}
 %
 % \subsection{其它}

--- a/hithesis.ins
+++ b/hithesis.ins
@@ -118,17 +118,17 @@ This is the configuration file of the hithesis package with LaTeX2e.
 %% mkdir -p 是幂等的，多次执行无副作用；需要 --shell-escape，否则 Makefile 会代劳。
 \immediate\write18{mkdir -p modules examples/hitbook/chinese/modules examples/hitbook/english/modules examples/hitart/reports/modules examples/hitart/reportplus/modules}
 \def\hitbookmod#1{%
-    \file{modules/hithesisbook-#1.sty}{\from{\jobname.dtx}{#1-book}}
-    \file{examples/hitbook/chinese/modules/hithesisbook-#1.sty}{\from{\jobname.dtx}{#1-book}}
-    \file{examples/hitbook/english/modules/hithesisbook-#1.sty}{\from{\jobname.dtx}{#1-book}}%
+    \file{modules/hithesisbook-#1.sty}{\from{\jobname.dtx}{book-#1}}
+    \file{examples/hitbook/chinese/modules/hithesisbook-#1.sty}{\from{\jobname.dtx}{book-#1}}
+    \file{examples/hitbook/english/modules/hithesisbook-#1.sty}{\from{\jobname.dtx}{book-#1}}%
 }
 \def\hitartmod#1{%
-    \file{modules/hithesisart-#1.sty}{\from{\jobname.dtx}{#1-art}}
-    \file{examples/hitart/reports/modules/hithesisart-#1.sty}{\from{\jobname.dtx}{#1-art}}%
+    \file{modules/hithesisart-#1.sty}{\from{\jobname.dtx}{art-#1}}
+    \file{examples/hitart/reports/modules/hithesisart-#1.sty}{\from{\jobname.dtx}{art-#1}}%
 }
 \def\hitartplusmod#1{%
-    \file{modules/hithesisartplus-#1.sty}{\from{\jobname.dtx}{#1-artplus}}
-    \file{examples/hitart/reportplus/modules/hithesisartplus-#1.sty}{\from{\jobname.dtx}{#1-artplus}}%
+    \file{modules/hithesisartplus-#1.sty}{\from{\jobname.dtx}{artplus-#1}}
+    \file{examples/hitart/reportplus/modules/hithesisartplus-#1.sty}{\from{\jobname.dtx}{artplus-#1}}%
 }
 \generate{
     \hitbookmod{options}     \hitartmod{options}     \hitartplusmod{options}


### PR DESCRIPTION
此前 hithesis 在三种命名位上字段顺序不一致：
  - sty 文件名 hithesisbook-options.sty (cls→职责)
  - docstrip 守卫 %<*options-book> (职责→cls)
  - cls 守卫 %<*bookcls> (cls 在前)

将 docstrip 守卫与 dtx 内的所有引用统一为 cls 在前：
  - %<*options-book>  → %<*book-options>
  - %</deps-artplus>  → %</artplus-deps>
  - 等 118 处守卫名
  - hithesis.ins 的 \\hitXmod 宏拼接顺序对应改为 X-#1
  - dtx 内 39 处 banner 注释与 76 处 prose/changes 引用同步

文件命名仍保持 LaTeX 包惯例 (hithesisX-Y.sty)，未改动。

验证：
  - 40/40 生成的 .sty 在非注释代码体上字节一致 (docstrip header 的 "(with options: `name')" 因模块名改变而变化，正常)
  - book/art/artplus 代表性变体编译通过
  - 手册编译正常 (196 页)

新增 CONTRIBUTING.md